### PR TITLE
Add double quotes escaping in git message

### DIFF
--- a/assets/helpers/git.sh
+++ b/assets/helpers/git.sh
@@ -66,7 +66,7 @@ add_pullrequest_metadata_commit() {
   local author_date=$(git log $filter --format=format:%ai)
   local committer=$(git log $filter --format=format:%cn)
   local committer_date=$(git log $filter --format=format:%ci)
-  local message=$(git log $filter --format=format:%B)
+  local message=$(git log $filter --format=format:%B | sed 's/\"/\\"/g')
 
   local metadata=""
   metadata+="{name: \"($1) commit\", value: \"${commit}\"},"

--- a/assets/in
+++ b/assets/in
@@ -138,5 +138,5 @@ git config --add pullrequest.merge $ref
 
 jq -n "{
   version: $(jq '.version' < "$payload"),
-  metadata: $(pullrequest_metadata "$prq_id" "$uri" )
+  metadata: $(pullrequest_metadata "$prq_id" "$uri")
 }" >&3

--- a/assets/out
+++ b/assets/out
@@ -185,5 +185,5 @@ jq -n "{
     hash: \"$prq_hash\",
     date: \"$(date_from_epoch_seconds "$prq_verify_date")\"
   },
-  metadata: $(pullrequest_metadata "$prq_number" "$uri" )
+  metadata: $(pullrequest_metadata "$prq_number" "$uri")
 }" >&3


### PR DESCRIPTION
Fixing fatal error as:
```
jq: error: syntax error, unexpected IDENT, expecting '}' (Unix shell quoting issues?) at <top-level>, line 6:
 ... "service/phpcs" ...
jq: 1 compile error
```