### PR TITLE
Always use pull request date for version date

### DIFF
--- a/assets/check
+++ b/assets/check
@@ -110,7 +110,7 @@ if [ -n "$pull_requests" ]; then
           text=$(echo "$comment" | jq -r '.text')
 
           # check for progress or finished messages => do not include in versions when available
-          if bitbucket_pullrequest_progress_commit_match "$text" "$prq_hash"; then
+          if bitbucket_pullrequest_comment_commit_match "$text" "$prq_hash"; then
             log "Skipping PRQ #$prq_number since already handled"
             skip_build=true
             break

--- a/assets/helpers/bitbucket.sh
+++ b/assets/helpers/bitbucket.sh
@@ -143,6 +143,16 @@ bitbucket_pullrequest_progress_commit_match() {
   echo "$comment" | grep -Ec "^$(regex_escape "$msg")" > /dev/null
 }
 
+bitbucket_pullrequest_comment_commit_match() {
+  # $1: pull request comment
+  # $2: pull request hash
+  local comment="$1"
+  local hash="$2"
+
+  local msg=")** for $hash into"
+  echo "$comment" | grep -Ec "$(regex_escape "$msg")" > /dev/null
+}
+
 bitbucket_pullrequest_progress_comment() {
   # $1: status (success, failure or pending)
   # $2: hash of merge commit

--- a/assets/in
+++ b/assets/in
@@ -45,6 +45,7 @@ submodules=$(jq -r '(.params.submodules // "all")' < "$payload")
 disable_git_lfs=$(jq -r '(.params.disable_git_lfs // false)' < "$payload")
 
 prq_id=$(jq -r '.version.id // ""' < "$payload")
+prq_date=$(jq -r '.version.date // ""' < "$payload")
 
 configure_git_ssl_verification "$skip_ssl_verification"
 configure_git_global "${git_config_payload}"
@@ -136,6 +137,7 @@ git config --add pullrequest.id $prq_id
 git config --add pullrequest.source $source_commit
 git config --add pullrequest.target $target_commit
 git config --add pullrequest.merge $ref
+git config --add pullrequest.date "$prq_date"
 
 jq -n "{
   version: $(jq '.version' < "$payload"),

--- a/assets/out
+++ b/assets/out
@@ -140,8 +140,8 @@ data=$(jq -cn "{
 # set commit build status for source commit
 bitbucket_pullrequest_commit_status "$repo_host" "$source_commit" "$data" "" "" "$skip_ssl_verification"
 
-# use the current commit timestamp as date
-prq_verify_date=$(git log -1 --format=format:%at)
+# use the pullrequest date stored in git config in get
+prq_verify_date=$(git config --get pullrequest.date | cat)
 
 # add comment to pull request to track if build was started/finished
 comment_message=$(bitbucket_pullrequest_progress_comment "$status" "$prq_hash" "$source_commit" "$target_commit")
@@ -165,7 +165,7 @@ if [ -n "$comments" ]; then
     # edit timestamp to force new build when rebuild_phrase is included in comments
     if [ "$skip_verify" != "true" ]; then
       if echo "$text" | grep -Ec "$rebuild_phrase" > /dev/null; then
-        prq_verify_date=$(( ($(echo "$comment" | jq -r '.createdDate') + 500) / 1000))
+        prq_verify_date=$(date_from_epoch_seconds $(( ($(echo "$comment" | jq -r '.createdDate') + 500) / 1000)))
         skip_verify=true
       fi
     fi
@@ -184,7 +184,7 @@ jq -n "{
   version: {
     id: \"$prq_number\",
     hash: \"$prq_hash\",
-    date: \"$(date_from_epoch_seconds "$prq_verify_date")\"
+    date: \"$prq_verify_date\"
   },
   metadata: $(pullrequest_metadata "$prq_number" "$uri" "$skip_ssl_verification")
 }" >&3


### PR DESCRIPTION
This commit fixes two issues:

1. If a git commit is amended and pushed after the PR is open, the put
to update the PR status will trigger additional builds. This is because
the date in the version in out is from the git commit which does not
match the PR date output by check.

2. In progress PRs were never skipped because in check containers
BUILD_ variables are not set. RESOURCE_ variables are set instead but
there is no guarantee that the resource name matches the job name. This
change makes check search comments using a smaller string that does not
depend on BUILD_ variables.