### PR TITLE
Add the possibility to authenticate using Personnal Access Tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ See [concourse docs](http://concourse.ci/configuring-resource-types.html) for mo
 
 * `password`: *Optional.* Password for HTTP(S) auth when pulling/pushing.
 
+* `token`: *Optional.* Token for HTTP(S) auth when pulling/pushing.
+  If you have configured a [personal access token](https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html), you can use it instead of your username and password.
+
 * `skip_ssl_verification`: *Optional.* Skips git ssl verification by exporting `GIT_SSL_NO_VERIFY=true`.
 
 * `git_config`: *Optional*. If specified as (list of pairs `name` and `value`) it will configure git global options, setting each name with each value.

--- a/assets/helpers/bitbucket.sh
+++ b/assets/helpers/bitbucket.sh
@@ -53,7 +53,7 @@ bitbucket_request() {
     extra_options+=" -k"
   fi
 
-  curl_cmd="curl -s --netrc-file \"$netrc_file\" $extra_options \"$request_url\" > \"$request_result\""
+  curl_cmd="curl -s --netrc-file \"$netrc_file\" $TOKEN $extra_options \"$request_url\" > \"$request_result\""
   if ! eval $curl_cmd; then
     log "Bitbucket request $request_url failed"
     exit 1

--- a/assets/helpers/git.sh
+++ b/assets/helpers/git.sh
@@ -107,9 +107,15 @@ pullrequest_metadata() {
 configure_credentials() {
   local username=$(jq -r '.source.username // ""' < $1)
   local password=$(jq -r '.source.password // ""' < $1)
+  local token=$(jq -r '.source.token // ""' < $1)
 
   rm -f $HOME/.netrc
   if [ "$username" != "" -a "$password" != "" ]; then
     echo "default login $username password $password" > $HOME/.netrc
+  fi
+
+  if [ "$token" != "" ]; then
+    git config --global --add http.extraHeader "Authorization: Bearer $token"
+    TOKEN="-H \"Authorization: Bearer $token\""
   fi
 }


### PR DESCRIPTION
This commit add an option in the resource source : the possibility to set a token that will be used in lieu of the username / password to authenticate to bitbucket.

The token is both added to the git config and to the curl command (via a global variable) so that every scenario of the resource can use it.